### PR TITLE
Add option to ignore files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #######################################
 # image for dev build environment
 ######################################
-FROM alpine:3.13 as dev
+FROM alpine:3.14.0 as dev
 
 ARG GH_CLI_VER=1.9.2
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This GitHub action will help you to keep track of the template changes.
 ## Features
 
 * Sync template repository with the current repository
-* Ignore files from syncing using `.templatesyncignore`
+* Ignore files and folders from syncing using a `.templatesyncignore` file
 ## Usage
 
 ### GitHub Actions
@@ -47,7 +47,7 @@ jobs:
 You will receive a pull request within your repository if there are some changes available.
 
 ## Ignore Files
-Create a `.templatesyncignore` file. All entries included in this file are ignored in the pull request. Follow the [glob pattern](https://en.wikipedia.org/wiki/Glob_(programming)).
+Create a `.templatesyncignore` file. Just like writing a `.gitignore` file, follow the [glob pattern](https://en.wikipedia.org/wiki/Glob_(programming)) in defining the files and folders that should be excluded from syncing with the template repository.
 
 ## Debug
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This GitHub action will help you to keep track of the template changes.
 ## Features
 
 * Sync template repository with the current repository
-
+* Ignore files from syncing using `.templatesyncignore`
 ## Usage
 
 ### GitHub Actions
@@ -45,6 +45,9 @@ jobs:
 ```
 
 You will receive a pull request within your repository if there are some changes available.
+
+## Ignore Files
+Create a `.templatesyncignore` file. All entries included in this file are ignored in the pull request. Follow the [glob pattern](https://en.wikipedia.org/wiki/Glob_(programming)).
 
 ## Debug
 

--- a/src/sync_template.sh
+++ b/src/sync_template.sh
@@ -58,13 +58,10 @@ git add .
 if [ -r ${TEMPLATE_SYNC_IGNORE_FILE_NAME} ]
 then
   echo "::debug::unstage files from template sync ignore"
-
-  while IFS= read -r line || [ -n "$line" ]; do
-    git reset "$line" -q
-  done < ${TEMPLATE_SYNC_IGNORE_FILE_NAME} 
+  git reset --pathspec-from-file="${TEMPLATE_SYNC_IGNORE_FILE_NAME}"
 
   echo "::debug::clean untracked files"
-  git clean -dfq
+  git clean -df
 
   echo "::debug::discard all unstaged changes"
   git checkout -- .

--- a/src/sync_template.sh
+++ b/src/sync_template.sh
@@ -19,6 +19,7 @@ if ! [ -x "$(command -v gh)" ]; then
 fi
 
 TEMPLATE_VERSION_FILE_NAME=".templateversionrc"
+TEMPLATE_SYNC_IGNORE_FILE_NAME=".templatesyncignore"
 TEMPLATE_REMOTE_GIT_HASH=$(git ls-remote "${SOURCE_REPO}" HEAD | awk '{print $1}')
 NEW_TEMPLATE_GIT_HASH=$(git rev-parse --short "${TEMPLATE_REMOTE_GIT_HASH}")
 NEW_BRANCH="chore/template_sync_${NEW_TEMPLATE_GIT_HASH}"
@@ -53,6 +54,13 @@ echo "::endgroup::"
 
 echo "::group::commit and push changes"
 git add .
+
+if [ -r ${TEMPLATE_SYNC_IGNORE_FILE_NAME} ]
+then
+  echo "::debug::unstage files from template sync ignore"
+  git reset `cat .templatesyncignore`
+fi
+
 git commit -m "chore(template): merge template changes :up:"
 
 echo "::debug::push changes"

--- a/src/sync_template.sh
+++ b/src/sync_template.sh
@@ -58,7 +58,7 @@ git add .
 if [ -r ${TEMPLATE_SYNC_IGNORE_FILE_NAME} ]
 then
   echo "::debug::unstage files from template sync ignore"
-  git reset `cat .templatesyncignore`
+  git reset `cat ${TEMPLATE_SYNC_IGNORE_FILE_NAME}`
 fi
 
 git commit -m "chore(template): merge template changes :up:"

--- a/src/sync_template.sh
+++ b/src/sync_template.sh
@@ -58,10 +58,13 @@ git add .
 if [ -r ${TEMPLATE_SYNC_IGNORE_FILE_NAME} ]
 then
   echo "::debug::unstage files from template sync ignore"
-  git reset `cat ${TEMPLATE_SYNC_IGNORE_FILE_NAME}`
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    git reset "$line" -q
+  done < ${TEMPLATE_SYNC_IGNORE_FILE_NAME} 
 
   echo "::debug::clean untracked files"
-  git clean -df
+  git clean -dfq
 
   echo "::debug::discard all unstaged changes"
   git checkout -- .

--- a/src/sync_template.sh
+++ b/src/sync_template.sh
@@ -59,6 +59,12 @@ if [ -r ${TEMPLATE_SYNC_IGNORE_FILE_NAME} ]
 then
   echo "::debug::unstage files from template sync ignore"
   git reset `cat ${TEMPLATE_SYNC_IGNORE_FILE_NAME}`
+
+  echo "::debug::clean untracked files"
+  git clean -df
+
+  echo "::debug::discard all unstaged changes"
+  git checkout -- .
 fi
 
 git commit -m "chore(template): merge template changes :up:"


### PR DESCRIPTION
# Description

Close #70 

- Added optional operation which unstages files from a `.templatesyncignore` file present in the repository. I took inspiration from this [StackOverflow answer](https://stackoverflow.com/a/15399452).
- The `.templatesyncignore` follows the glob pattern as desired.
- Updated `README` to document ignoring of files.

## Remark

For automation please see [closing-issues-using-keywords](
    https://help.github.com/en/articles/closing-issues-using-keywords)
