### PR TITLE
feat(gh-auth): add gh auth login and credential helper

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,11 @@ jobs:
 
     steps:
       # To use this repository's private action, you must check out the repository
-      - name: Checkout
+      -
+        name: Checkout
         uses: actions/checkout@v3
-      - name: Test action step
+      -
+        name: Test action step
         uses: ./ # Uses an action in the root directory
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_pat.yml
+++ b/.github/workflows/test_pat.yml
@@ -1,4 +1,4 @@
-name: test-ssh
+name: test-pat
 
 on:
   pull_request:
@@ -17,10 +17,9 @@ jobs:
         name: Checkout
         uses: actions/checkout@v3
       -
-        name: Test action step ssh
+        name: Test action step PAT
         uses: ./ # Uses an action in the root directory
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.SOURCE_REPO_PAT }}
           source_repo_path: ${{ secrets.SOURCE_REPO_PATH_TEST }} # <owner/repo>, should be within secrets
-          source_repo_ssh_private_key: ${{ secrets.SOURCE_REPO_SSH_PRIVATE_KEY }} # contains the private ssh key of the private repository
           is_dry_run: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@
 ######################################
 FROM alpine:3.17.0 as dev
 
-ARG GH_CLI_VER=2.15.0
+ARG GH_CLI_VER=2.21.1
 
 # install packages
-RUN apk add --update --no-cache bash make git zsh curl tmux musl openssh git-lfs
+RUN apk add --update --no-cache bash make git zsh curl tmux musl openssh git-lfs vim
 
 RUN wget https://github.com/cli/cli/releases/download/v${GH_CLI_VER}/gh_${GH_CLI_VER}_linux_386.tar.gz -O ghcli.tar.gz
 RUN tar --strip-components=1 -xf ghcli.tar.gz
@@ -16,6 +16,11 @@ RUN echo "set-option -g default-shell /bin/zsh" >> /root/.tmux.conf
 
 # install oh-my-zsh
 RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
+
+ADD src/*.sh /bin/
+RUN chmod +x /bin/entrypoint.sh \
+  && chmod +x /bin/sync_template.sh \
+  && chmod +x /bin/sync_common.sh
 
 RUN mkdir -p /root/.ssh \
   && ssh-keyscan -t rsa github.com >> /root/.ssh/known_hosts

--- a/README.md
+++ b/README.md
@@ -63,12 +63,8 @@ You will receive a pull request within your repository if there are some changes
 | github_token | Token for the repo. Can be passed in using `$\{{ secrets.GITHUB_TOKEN }}` | `true` |  |
 | source_repo_path | Repository path of the template | `true` | |
 | upstream_branch | The target branch | `true` | `main` |
-<<<<<<< HEAD
-| source_repo_ssh_private_key | `[optional]` private ssh key for the source repository. [see](#private-template-repository)| `false` |  |
-=======
 | source_repo_ssh_private_key | `[optional]` private ssh key for the source repository. E.q. useful if using a private template repository. [see](#private-template-repository)| `false` |  |
 | source_repo_github_token | `[optional]` separate github token to interact with the source repository. | `false` | `$\{{ inputs.github_token }}` |
->>>>>>> 42e4d55 (feat(gh-auth): add own source_repo_github_token handling for template repo)
 | pr_branch_name_prefix | `[optional]` the prefix of branches created by this action | `false` | `chore/template_sync`  |
 | pr_title | `[optional]` the title of PRs opened by this action. Must be already created. | `false` | `upstream merge template repository`  |
 | pr_labels | `[optional]` comma separated list. [pull request labels][pr-labels]. Must be already created. | `false` | |

--- a/README.md
+++ b/README.md
@@ -63,8 +63,7 @@ You will receive a pull request within your repository if there are some changes
 | github_token | Token for the repo. Can be passed in using `$\{{ secrets.GITHUB_TOKEN }}` | `true` |  |
 | source_repo_path | Repository path of the template | `true` | |
 | upstream_branch | The target branch | `true` | `main` |
-| source_repo_ssh_private_key | `[optional]` private ssh key for the source repository. E.q. useful if using a private template repository. [see](#private-template-repository)| `false` |  |
-| source_repo_github_token | `[optional]` separate github token to interact with the source repository. | `false` | `$\{{ inputs.github_token }}` |
+| source_repo_ssh_private_key | `[optional]` private ssh key for the source repository. [see](#private-template-repository)| `false` |  |
 | pr_branch_name_prefix | `[optional]` the prefix of branches created by this action | `false` | `chore/template_sync`  |
 | pr_title | `[optional]` the title of PRs opened by this action. Must be already created. | `false` | `upstream merge template repository`  |
 | pr_labels | `[optional]` comma separated list. [pull request labels][pr-labels]. Must be already created. | `false` | |
@@ -89,7 +88,8 @@ If you have a private template repository.
 
 #### Using github app
 
-You can create and use a [GitHub App](https://docs.github.com/en/developers/apps/getting-started-with-apps/about-apps#about-github-apps) to handle the access to your private repository. To generate a token for your app you can use a separate action like [tibdex/github-app-token](https://github.com/tibdex/github-app-token).
+You can create and use a [GitHub App][github-app] to handle the access to your private repository.
+To generate a token for your app you can use a separate action like [tibdex/github-app-token][github-app-token].
 
 ```yaml
 jobs:
@@ -105,10 +105,9 @@ jobs:
           private_key: ${{ secrets.PRIVATE_KEY }}
 
       - name: actions-template-sync
-        uses: AndreasAugustin/actions-template-sync@v0.5.0-draft
+        uses: AndreasAugustin/actions-template-sync@v0.5.5-draft
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          source_repo_github_token: ${{ steps.generate_token.outputs.token }}
+          github_token: ${{ steps.generate_token.outputs.token }}
           source_repo_path: <owner/repo>
           upstream_branch: <target_branch> # defaults to main
           pr_labels: <label1>,<label2>[,...] # optional, no default
@@ -143,7 +142,7 @@ jobs:
 
 ## Ignore Files
 
-Create a `.templatesyncignore` file. Just like writing a `.gitignore` file, follow the [glob pattern](https://en.wikipedia.org/wiki/Glob_(programming))
+Create a `.templatesyncignore` file. Just like writing a `.gitignore` file, follow the [glob pattern][glob-pattern]
 in defining the files and folders that should be excluded from syncing with the template repository.
 
 It can also be stored inside `.github` folder.
@@ -212,3 +211,6 @@ specification. Contributions of any kind welcome!
 [pr-labels]: https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels
 [devto-example]: https://dev.to/andreasaugustin/github-actions-template-sync-1g9k
 [github-example]: https://github.com/AndreasAugustin/teaching/blob/main/docs/git/git_action_sync.md
+[github-app]: https://docs.github.com/en/developers/apps/getting-started-with-apps/about-apps#about-github-apps
+[glob-pattern]: https://en.wikipedia.org/wiki/Glob_(programming)
+[github-app-token]: https://github.com/tibdex/github-app-token

--- a/README.md
+++ b/README.md
@@ -63,7 +63,12 @@ You will receive a pull request within your repository if there are some changes
 | github_token | Token for the repo. Can be passed in using `$\{{ secrets.GITHUB_TOKEN }}` | `true` |  |
 | source_repo_path | Repository path of the template | `true` | |
 | upstream_branch | The target branch | `true` | `main` |
+<<<<<<< HEAD
 | source_repo_ssh_private_key | `[optional]` private ssh key for the source repository. [see](#private-template-repository)| `false` |  |
+=======
+| source_repo_ssh_private_key | `[optional]` private ssh key for the source repository. E.q. useful if using a private template repository. [see](#private-template-repository)| `false` |  |
+| source_repo_github_token | `[optional]` separate github token to interact with the source repository. | `false` | `$\{{ inputs.github_token }}` |
+>>>>>>> 42e4d55 (feat(gh-auth): add own source_repo_github_token handling for template repo)
 | pr_branch_name_prefix | `[optional]` the prefix of branches created by this action | `false` | `chore/template_sync`  |
 | pr_title | `[optional]` the title of PRs opened by this action. Must be already created. | `false` | `upstream merge template repository`  |
 | pr_labels | `[optional]` comma separated list. [pull request labels][pr-labels]. Must be already created. | `false` | |
@@ -85,6 +90,33 @@ You can use all [triggers][action-triggers] which are supported for GitHub actio
 ### Private template repository
 
 If you have a private template repository.
+
+#### Using github app
+
+You can create and use a [GitHub App](https://docs.github.com/en/developers/apps/getting-started-with-apps/about-apps#about-github-apps) to handle the access to your private repository. To generate a token for your app you can use a separate action like [tibdex/github-app-token](https://github.com/tibdex/github-app-token).
+
+```yaml
+jobs:
+  repo-sync:
+    runs-on: ubuntu-latest
+
+    steps:
+     - name: Generate token to read from source repo # see: https://github.com/tibdex/github-app-token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: actions-template-sync
+        uses: AndreasAugustin/actions-template-sync@v0.5.0-draft
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          source_repo_github_token: ${{ steps.generate_token.outputs.token }}
+          source_repo_path: <owner/repo>
+          upstream_branch: <target_branch> # defaults to main
+          pr_labels: <label1>,<label2>[,...] # optional, no default
+```
 
 #### SSH
 

--- a/action.yml
+++ b/action.yml
@@ -17,8 +17,6 @@ inputs:
     default: 'main'
   source_repo_ssh_private_key:
     description: '[optional] private ssh key for the source repository. E.q. useful if using a private template repository.'
-  source_repo_github_token:
-    description: '[optional] Separate github token to interact with the source repository. Using $\{{ inputs.github_token }} by default.'
   pr_branch_name_prefix:
     description: '[optional] the prefix of branches created by this action'
     default: 'chore/template_sync'
@@ -40,7 +38,6 @@ runs:
   image: 'src/Dockerfile'
   env:
     GITHUB_TOKEN: ${{ inputs.github_token }}
-    SOURCE_REPO_GITHUB_TOKEN: ${{ inputs.source_repo_github_token }}
     SOURCE_REPO_PATH: ${{ inputs.source_repo_path }}
     UPSTREAM_BRANCH: ${{ inputs.upstream_branch }}
     SSH_PRIVATE_KEY_SRC: ${{ inputs.source_repo_ssh_private_key }}

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,8 @@ inputs:
     default: 'main'
   source_repo_ssh_private_key:
     description: '[optional] private ssh key for the source repository. E.q. useful if using a private template repository.'
+  source_repo_github_token:
+    description: '[optional] Separate github token to interact with the source repository. Using $\{{ inputs.github_token }} by default.'
   pr_branch_name_prefix:
     description: '[optional] the prefix of branches created by this action'
     default: 'chore/template_sync'
@@ -38,6 +40,7 @@ runs:
   image: 'src/Dockerfile'
   env:
     GITHUB_TOKEN: ${{ inputs.github_token }}
+    SOURCE_REPO_GITHUB_TOKEN: ${{ inputs.source_repo_github_token }}
     SOURCE_REPO_PATH: ${{ inputs.source_repo_path }}
     UPSTREAM_BRANCH: ${{ inputs.upstream_branch }}
     SSH_PRIVATE_KEY_SRC: ${{ inputs.source_repo_ssh_private_key }}

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.17.0
 
-ARG GH_CLI_VER=2.15.0
+ARG GH_CLI_VER=2.21.1
 
 # TODO(anau) change user
 ARG GITHUB_URL="https://github.com/AndreasAugustin/actions-template-sync"

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -6,14 +6,9 @@ set -x
 # shellcheck source=src/sync_common.sh
 source sync_common.sh
 
-[ -z "${GITHUB_TOKEN}" ] && {
-  err "Missing input 'github_token: \${{ secrets.GITHUB_TOKEN }}'.";
-  exit 1;
-};
-
-if [[ -z "${SOURCE_REPO_GITHUB_TOKEN}" ]]; then
-  echo "::debug::Missing input 'source_repo_github_token: \${{ input.source_repo_github_token }}'. Using github_token as default."
-  SOURCE_REPO_GITHUB_TOKEN="${GITHUB_TOKEN}"
+if [[ -z "${GITHUB_TOKEN}" ]]; then
+    err "Missing input 'github_token: \${{ secrets.GITHUB_TOKEN }}'.";
+    exit 1;
 fi
 
 if [[ -z "${SOURCE_REPO_PATH}" ]]; then
@@ -21,9 +16,10 @@ if [[ -z "${SOURCE_REPO_PATH}" ]]; then
   exit 1
 fi
 
-SOURCE_REPO_HOSTNAME="${HOSTNAME:-github.com}"
+DEFAULT_REPO_HOSTNAME="github.com"
+SOURCE_REPO_HOSTNAME="${HOSTNAME:-${DEFAULT_REPO_HOSTNAME}}"
 
-# In case of private template repository this will be overwritten
+# In case of ssh template repository this will be overwritten
 SOURCE_REPO_PREFIX="https://${SOURCE_REPO_HOSTNAME}/"
 
 function ssh_setup() {
@@ -46,6 +42,9 @@ function ssh_setup() {
 # Forward to /dev/null to swallow the output of the private key
 if [[ -n "${SSH_PRIVATE_KEY_SRC}" ]] &>/dev/null; then
   ssh_setup
+elif [[ "${SOURCE_REPO_HOSTNAME}" != "${DEFAULT_REPO_HOSTNAME}" ]]; then
+  # git config --global "credential.https://${SOURCE_REPO_HOSTNAME}.helper" "!gh auth git-credential"
+  gh auth login --git-protocol "https" --hostname "${SOURCE_REPO_HOSTNAME}" --with-token <<< "${GITHUB_TOKEN}"
 fi
 
 export SOURCE_REPO="${SOURCE_REPO_PREFIX}${SOURCE_REPO_PATH}"
@@ -60,9 +59,8 @@ function git_init() {
   git config --global --add safe.directory /github/workspace
   git lfs install
 
-  git config --global "credential.https://${SOURCE_REPO_HOSTNAME}.helper" "!gh auth git-credential"
-  gh auth login --git-protocol "https" --hostname "${SOURCE_REPO_HOSTNAME}" --with-token <<< "${GITHUB_TOKEN}"
-
+  gh auth setup-git --hostname "${SOURCE_REPO_HOSTNAME}"
+  gh auth status --hostname "${SOURCE_REPO_HOSTNAME}"
   echo "::endgroup::"
 }
 

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -50,7 +50,6 @@ fi
 
 export SOURCE_REPO="${SOURCE_REPO_PREFIX}${SOURCE_REPO_PATH}"
 
-<<<<<<< HEAD
 function git_init() {
   echo "::group::git init"
   info "set git global configuration"
@@ -68,16 +67,6 @@ function git_init() {
 }
 
 git_init
-=======
-echo "::group::git init"
-echo "set git global configuration"
-git config --global user.email "github-action@actions-template-sync.noreply.${SOURCE_REPO_HOSTNAME}"
-git config --global user.name "${GITHUB_ACTOR}"
-git config --global pull.rebase false
-git config --global --add safe.directory /github/workspace
-git config --global "credential.https://${SOURCE_REPO_HOSTNAME}.helper" "!gh auth git-credential"
-echo "::endgroup::"
->>>>>>> 42e4d55 (feat(gh-auth): add own source_repo_github_token handling for template repo)
 
 # shellcheck source=src/sync_template.sh
 source sync_template.sh

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -43,7 +43,6 @@ function ssh_setup() {
 if [[ -n "${SSH_PRIVATE_KEY_SRC}" ]] &>/dev/null; then
   ssh_setup
 elif [[ "${SOURCE_REPO_HOSTNAME}" != "${DEFAULT_REPO_HOSTNAME}" ]]; then
-  # git config --global "credential.https://${SOURCE_REPO_HOSTNAME}.helper" "!gh auth git-credential"
   gh auth login --git-protocol "https" --hostname "${SOURCE_REPO_HOSTNAME}" --with-token <<< "${GITHUB_TOKEN}"
 fi
 

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -11,6 +11,11 @@ source sync_common.sh
   exit 1;
 };
 
+if [[ -z "${SOURCE_REPO_GITHUB_TOKEN}" ]]; then
+  echo "::debug::Missing input 'source_repo_github_token: \${{ input.source_repo_github_token }}'. Using github_token as default."
+  SOURCE_REPO_GITHUB_TOKEN="${GITHUB_TOKEN}"
+fi
+
 if [[ -z "${SOURCE_REPO_PATH}" ]]; then
   err "Missing input 'source_repo_path: \${{ input.source_repo_path }}'.";
   exit 1
@@ -45,6 +50,7 @@ fi
 
 export SOURCE_REPO="${SOURCE_REPO_PREFIX}${SOURCE_REPO_PATH}"
 
+<<<<<<< HEAD
 function git_init() {
   echo "::group::git init"
   info "set git global configuration"
@@ -62,6 +68,16 @@ function git_init() {
 }
 
 git_init
+=======
+echo "::group::git init"
+echo "set git global configuration"
+git config --global user.email "github-action@actions-template-sync.noreply.${SOURCE_REPO_HOSTNAME}"
+git config --global user.name "${GITHUB_ACTOR}"
+git config --global pull.rebase false
+git config --global --add safe.directory /github/workspace
+git config --global "credential.https://${SOURCE_REPO_HOSTNAME}.helper" "!gh auth git-credential"
+echo "::endgroup::"
+>>>>>>> 42e4d55 (feat(gh-auth): add own source_repo_github_token handling for template repo)
 
 # shellcheck source=src/sync_template.sh
 source sync_template.sh

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -19,7 +19,7 @@ fi
 SOURCE_REPO_HOSTNAME="${HOSTNAME:-github.com}"
 
 # In case of private template repository this will be overwritten
-SOURCE_REPO_PREFIX="https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@${SOURCE_REPO_HOSTNAME}/"
+SOURCE_REPO_PREFIX="https://${SOURCE_REPO_HOSTNAME}/"
 
 function ssh_setup() {
   echo "::group::ssh setup"
@@ -54,6 +54,9 @@ function git_init() {
   git config --global pull.rebase false
   git config --global --add safe.directory /github/workspace
   git lfs install
+
+  git config --global "credential.https://${SOURCE_REPO_HOSTNAME}.helper" "!gh auth git-credential"
+  gh auth login --git-protocol "https" --hostname "${SOURCE_REPO_HOSTNAME}" --with-token <<< "${GITHUB_TOKEN}"
 
   echo "::endgroup::"
 }

--- a/src/sync_template.sh
+++ b/src/sync_template.sh
@@ -62,13 +62,9 @@ echo "::endgroup::"
 echo "::group::Pull template"
 debug "create new branch from default branch with name ${NEW_BRANCH}"
 git checkout -b "${NEW_BRANCH}"
-<<<<<<< HEAD
 debug "pull changes from template"
-# TODO(anau) eventually make squash optional
-=======
-echo "::debug::pull changes from template"
 gh auth login --git-protocol "https" --hostname "${SOURCE_REPO_HOSTNAME}" --with-token <<< "${SOURCE_REPO_GITHUB_TOKEN}"
->>>>>>> 42e4d55 (feat(gh-auth): add own source_repo_github_token handling for template repo)
+# TODO(anau) eventually make squash optional
 git pull "${SOURCE_REPO}" --allow-unrelated-histories --squash --strategy=recursive -X theirs
 echo "::endgroup::"
 
@@ -108,16 +104,11 @@ echo "::endgroup::"
 
 push_and_create_pr () {
   if [ "$IS_DRY_RUN" != "true" ]; then
-<<<<<<< HEAD
-		echo "::group::push changes and create PR"
-    debug "push changes"
-=======
     echo "::group::final gh auth login before creating pull request"
     gh auth login --git-protocol "https" --hostname "${SOURCE_REPO_HOSTNAME}" --with-token <<< "${GITHUB_TOKEN}"
     echo "::endgroup::"
 
-    echo "::debug::push changes"
->>>>>>> 42e4d55 (feat(gh-auth): add own source_repo_github_token handling for template repo)
+    echo "::group::push changes and create PR"
     git push --set-upstream origin "${NEW_BRANCH}"
 
     gh pr create \

--- a/src/sync_template.sh
+++ b/src/sync_template.sh
@@ -63,7 +63,7 @@ echo "::group::Pull template"
 debug "create new branch from default branch with name ${NEW_BRANCH}"
 git checkout -b "${NEW_BRANCH}"
 debug "pull changes from template"
-gh auth login --git-protocol "https" --hostname "${SOURCE_REPO_HOSTNAME}" --with-token <<< "${SOURCE_REPO_GITHUB_TOKEN}"
+
 # TODO(anau) eventually make squash optional
 git pull "${SOURCE_REPO}" --allow-unrelated-histories --squash --strategy=recursive -X theirs
 echo "::endgroup::"
@@ -104,11 +104,9 @@ echo "::endgroup::"
 
 push_and_create_pr () {
   if [ "$IS_DRY_RUN" != "true" ]; then
-    echo "::group::final gh auth login before creating pull request"
-    gh auth login --git-protocol "https" --hostname "${SOURCE_REPO_HOSTNAME}" --with-token <<< "${GITHUB_TOKEN}"
-    echo "::endgroup::"
 
     echo "::group::push changes and create PR"
+    debug "push changes"
     git push --set-upstream origin "${NEW_BRANCH}"
 
     gh pr create \

--- a/src/sync_template.sh
+++ b/src/sync_template.sh
@@ -62,8 +62,13 @@ echo "::endgroup::"
 echo "::group::Pull template"
 debug "create new branch from default branch with name ${NEW_BRANCH}"
 git checkout -b "${NEW_BRANCH}"
+<<<<<<< HEAD
 debug "pull changes from template"
 # TODO(anau) eventually make squash optional
+=======
+echo "::debug::pull changes from template"
+gh auth login --git-protocol "https" --hostname "${SOURCE_REPO_HOSTNAME}" --with-token <<< "${SOURCE_REPO_GITHUB_TOKEN}"
+>>>>>>> 42e4d55 (feat(gh-auth): add own source_repo_github_token handling for template repo)
 git pull "${SOURCE_REPO}" --allow-unrelated-histories --squash --strategy=recursive -X theirs
 echo "::endgroup::"
 
@@ -103,8 +108,16 @@ echo "::endgroup::"
 
 push_and_create_pr () {
   if [ "$IS_DRY_RUN" != "true" ]; then
+<<<<<<< HEAD
 		echo "::group::push changes and create PR"
     debug "push changes"
+=======
+    echo "::group::final gh auth login before creating pull request"
+    gh auth login --git-protocol "https" --hostname "${SOURCE_REPO_HOSTNAME}" --with-token <<< "${GITHUB_TOKEN}"
+    echo "::endgroup::"
+
+    echo "::debug::push changes"
+>>>>>>> 42e4d55 (feat(gh-auth): add own source_repo_github_token handling for template repo)
     git push --set-upstream origin "${NEW_BRANCH}"
 
     gh pr create \


### PR DESCRIPTION
# Description

Close #238

With this PR `gh` will be used to authenticate the repository by the used `GITHUB_TOKEN`.

This change is tested against GitHub Enterprise v3.5. It would be lovely if you could test it also against your setup on github.com.