### PR TITLE
fix(sync-template): typo in TEMPLATE_SYNC_IGNORE_FILE_PATH variables

### DIFF
--- a/src/sync_template.sh
+++ b/src/sync_template.sh
@@ -56,11 +56,11 @@ debug "pull changes from template"
 git pull "${SOURCE_REPO}" --allow-unrelated-histories --squash --strategy=recursive -X theirs
 echo "::endgroup::"
 
-if [ -s "${TEMPLATE_SYNC_IGNORE_FILE_NAME}" ]; then
+if [ -s "${TEMPLATE_SYNC_IGNORE_FILE_PATH}" ]; then
   echo "::group::restore ignore file"
 	info "restore the ignore file"
-  git reset "${TEMPLATE_SYNC_IGNORE_FILE_NAME}"
-  git checkout -- "${TEMPLATE_SYNC_IGNORE_FILE_NAME}"
+  git reset "${TEMPLATE_SYNC_IGNORE_FILE_PATH}"
+  git checkout -- "${TEMPLATE_SYNC_IGNORE_FILE_PATH}"
   echo "::endgroup::"
 fi
 


### PR DESCRIPTION
# Description

Close #267 


## Remark

For automation please see [closing-issues-using-keywords](
    https://help.github.com/en/articles/closing-issues-using-keywords)
