### PR TITLE
bug fix version bump 0.7.1-draft

### DIFF
--- a/.github/workflows/actions_template_sync.yml
+++ b/.github/workflows/actions_template_sync.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: actions-template-sync
-        uses: AndreasAugustin/actions-template-sync@v0.7.0-draft
+        uses: AndreasAugustin/actions-template-sync@v0.7.1-draft
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           source_repo_path: AndreasAugustin/template

--- a/.github/workflows/test_ssh_gitlab.yml
+++ b/.github/workflows/test_ssh_gitlab.yml
@@ -1,0 +1,27 @@
+name: test-ssh
+
+on:
+  pull_request:
+  push:
+  # manual trigger
+  workflow_dispatch:
+
+jobs:
+  test-implementation-job:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      # To use this repository's private action, you must check out the repository
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Test action step ssh
+        uses: ./ # Uses an action in the root directory
+        with:
+          hostname: ${{ secrets.SOURCE_REPO_GITLAB_HOSTNAME }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          source_repo_path: ${{ secrets.SOURCE_REPO_GITLAB_PATH }} # <owner/repo>, should be within secrets
+          source_repo_ssh_private_key: ${{ secrets.SOURCE_REPO_GITLAB_SSH_PRIVATE_KEY }} # contains the private ssh key of the private repository
+          is_dry_run: true

--- a/.github/workflows/test_ssh_gitlab.yml
+++ b/.github/workflows/test_ssh_gitlab.yml
@@ -1,4 +1,4 @@
-name: test-ssh
+name: test-ssh-gitlab
 
 on:
   pull_request:
@@ -25,3 +25,4 @@ jobs:
           source_repo_path: ${{ secrets.SOURCE_REPO_GITLAB_PATH }} # <owner/repo>, should be within secrets
           source_repo_ssh_private_key: ${{ secrets.SOURCE_REPO_GITLAB_SSH_PRIVATE_KEY }} # contains the private ssh key of the private repository
           is_dry_run: true
+          is_not_source_github: true

--- a/README.md
+++ b/README.md
@@ -36,10 +36,6 @@ This GitHub action will help you to keep track of the template changes.
 
 ## Usage
 
-### Update
-
-starting with version v0.5.2-draft the `templateversionrc` file is not needed anymore. You can delete that file from the target repositories.
-
 ### Public template repository
 
 Add this configuration to your github action
@@ -62,7 +58,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: actions-template-sync
-        uses: AndreasAugustin/actions-template-sync@v0.7.0-draft
+        uses: AndreasAugustin/actions-template-sync@v0.7.1-draft
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           source_repo_path: <owner/repo>
@@ -95,7 +91,7 @@ jobs:
           private_key: ${{ secrets.PRIVATE_KEY }}
 
       - name: actions-template-sync
-        uses: AndreasAugustin/actions-template-sync@v0.7.0-draft
+        uses: AndreasAugustin/actions-template-sync@v0.7.1-draft
         with:
           github_token: ${{ steps.generate_token.outputs.token }}
           source_repo_path: <owner/repo>
@@ -122,7 +118,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: actions-template-sync
-        uses: AndreasAugustin/actions-template-sync@v0.7.0-draft
+        uses: AndreasAugustin/actions-template-sync@v0.7.1-draft
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           source_repo_path: ${{ secrets.SOURCE_REPO_PATH }} # <owner/repo>, should be within secrets
@@ -222,6 +218,10 @@ To ignore those, simply create a file in the root directory named `.templatesync
 
 Open your project `Settings > Actions > General` and select the checkbox `Allow Github Actions to create and approve pull requests`
 under the `Workflow permissions` section.
+
+## Release Updates
+
+starting with version v0.5.2-draft the `templateversionrc` file is not needed anymore. You can delete that file from the target repositories.
 
 ## Debug
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This GitHub action will help you to keep track of the template changes.
 * Ignore files and folders from syncing using a `.templatesyncignore` file
 * many configuration options
 * different lifecycle hooks are supported
+* different git provider. Default is GitHub, GitLab is also tested. See [.github/workflows/test_ssh_gitlab.yml] for an example.
 
 ## Usage
 
@@ -109,6 +110,7 @@ An example are [deployment keys][deployment-keys]. For our use case write permis
 Within the repository where the GitHub action is enabled add a secret (e.q. `SOURCE_REPO_SSH_PRIVATE_KEY`) with the content of your private SSH key.
 Make sure that the read permissions of that secret fulfil your use case.
 Set the optional `source_repo_ssh_private_key` input parameter.
+It is also possible to use a different git provider, e.g. GitLab.
 
 ```yaml
 jobs:
@@ -144,6 +146,7 @@ jobs:
 | hostname | `[optional]` the hostname of the repository | `false` | `github.com` |
 | is_dry_run | `[optional]` set to `true` if you do not want to push the changes and not want to create a PR |  `false` |   |
 | is_allow_hooks | `[optional]` set to `true` if you want to enable lifecycle hooks. Use this with caution! | `false` | `false` |
+| is_not_source_github | `[optional]` set to `true` if the source git provider is not GitHub | `false` | `false` |
 
 ### Example
 

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,9 @@ inputs:
   is_allow_hooks:
     description: '[optional] set to true if you want to allow hooks. Use this functionality with caution!'
     default: 'false'
+  is_not_source_github:
+    description: '[optional] set to true if the source repository is not a github related repository. Useful e.q. if the source is GitLab'
+    default: 'false'
 runs:
   using: 'docker'
   image: 'src/Dockerfile'
@@ -51,3 +54,4 @@ runs:
     HOSTNAME: ${{ inputs.hostname }}
     IS_DRY_RUN: ${{ inputs.is_dry_run }}
     IS_ALLOW_HOOKS: ${{ inputs.is_allow_hooks }}
+    IS_NOT_SOURCE_GITHUB: ${{ inputs.is_not_source_github }}

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -60,6 +60,7 @@ function git_init() {
 
   if [[ -n "${IS_NOT_SOURCE_GITHUB}" ]]; then
     info "the source repository is not located within GitHub."
+    ssh-keyscan -t rsa "${SOURCE_REPO_HOSTNAME}" >> /root/.ssh/known_hosts
   else
     info "the source repository is located within GitHub."
     gh auth setup-git --hostname "${SOURCE_REPO_HOSTNAME}"

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -58,8 +58,13 @@ function git_init() {
   git config --global --add safe.directory /github/workspace
   git lfs install
 
-  gh auth setup-git --hostname "${SOURCE_REPO_HOSTNAME}"
-  gh auth status --hostname "${SOURCE_REPO_HOSTNAME}"
+  if [[ -n "${IS_NOT_SOURCE_GITHUB}" ]]; then
+    info "the source repository is not located within GitHub."
+  else
+    info "the source repository is located within GitHub."
+    gh auth setup-git --hostname "${SOURCE_REPO_HOSTNAME}"
+    gh auth status --hostname "${SOURCE_REPO_HOSTNAME}"
+  fi
   echo "::endgroup::"
 }
 


### PR DESCRIPTION
# Description

Close #278 

bug fix, now other git providers (e.g. GitLab) are able to be used with e.g. ssh.


## Remark

For automation please see [closing-issues-using-keywords](
    https://help.github.com/en/articles/closing-issues-using-keywords)
