### PR TITLE
fix: checkout action using a github pat

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,11 +200,13 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.CUSTOM_GITHUB_PAT }}
       -
         name: Test action step PAT
         uses: AndreasAugustin/actions-template-sync@v1.0.0-draft
         with:
-          github_token: ${{ secrets.SOURCE_REPO_PAT }}
+          github_token: ${{ secrets.CUSTOM_GITHUB_PAT }}
           source_repo_path: ${{ secrets.SOURCE_REPO_PATH }} # <owner/repo>, should be within secrets
 ```
 


### PR DESCRIPTION
# Description

Close #357

This will fix a checkout issue when using a GitHub PAT.
I also renamed the PAT variable from `SOURCE_REPO_PAT` to `CUSTOM_GITHUB_PAT` in order to avoid match overlap with `SOURCE_REPO_PATH`.

## Remark

For automation please see [closing-issues-using-keywords](
    https://help.github.com/en/articles/closing-issues-using-keywords)
