### PR TITLE
fix: :bug: (#375) fix edge case with .templatesyncignore

### DIFF
--- a/src/sync_template.sh
+++ b/src/sync_template.sh
@@ -83,7 +83,7 @@ if [ -s "${TEMPLATE_SYNC_IGNORE_FILE_PATH}" ]; then
   echo "::group::restore ignore file"
   info "restore the ignore file"
   git reset "${TEMPLATE_SYNC_IGNORE_FILE_PATH}"
-  git checkout -- "${TEMPLATE_SYNC_IGNORE_FILE_PATH}"
+  git checkout -- "${TEMPLATE_SYNC_IGNORE_FILE_PATH}" || warn "not able to checkout the former .templatesyncignore file. Most likely the file was not present"
   echo "::endgroup::"
 fi
 


### PR DESCRIPTION
when there is an .templatesyncignore file present within source repository but not in target repo, the program stopped

# Description

Close #375 

## Remark

For automation please see [closing-issues-using-keywords](
    https://help.github.com/en/articles/closing-issues-using-keywords)
