### PR TITLE
feat(#440): :sparkles:  add precommit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ The following hooks are supported (please check [docs/ARCHITECTURE.md](docs/ARCH
 
 * `install` is executed after the container has started and after reading and setting up the environment.
 * `prepull` is executed before the code is pulled from the source repository
+* `precommit` is executed before the code is commited
 * `prepush` is executed before the push is executed, right after the commit
 * `prepr` is executed before the PR is done
 
@@ -320,6 +321,10 @@ hooks:
     commands:
       - echo 'hi, we are within the prepull phase'
       - echo 'maybe you want to do adjustments on the local code'
+  precommit:
+    commands:
+      - echo 'hi, we are within the precommit phase'
+      - echo 'maybe you want to add further changes before the code is committed'
   prepush:
     commands:
       - echo 'hi, we are within the prepush phase'

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -35,7 +35,7 @@ GitCommitSync["fa:fa-code-commit Commit the changes"]
 CheckIsDryRun{"Check if is_dry_run is set to true"}
 GitPushSync["Push the changes to GitHub"]
 GitPullRequestSync["fa:fa-code-pull-request Create a pull request on GitHub"]
-Hook{{"hooks, <b>prepush | prepush | prepr</b>"}}
+Hook{{"hooks, <b>prepull | precommit | prepush | prepr</b>"}}
 
 subgraph githubactions["fa:fa-github GitHubActions"]
 

--- a/src/sync_template.sh
+++ b/src/sync_template.sh
@@ -94,6 +94,8 @@ if [ -s "${TEMPLATE_SYNC_IGNORE_FILE_PATH}" ]; then
   echo "::endgroup::"
 fi
 
+cmd_from_yml_file "precommit"
+
 echo "::group::commit changes"
 git add .
 


### PR DESCRIPTION
# Description

This adds a new hook `precommit` right before the code is committed.  This is done to avoid having to re-commit any changes in the `prepush` hook.

## Remark

For automation please see [closing-issues-using-keywords](
    https://help.github.com/en/articles/closing-issues-using-keywords)
