### PR TITLE
feat(#467): :sparkles: hooks now within action inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ jobs:
 | hostname                    | `[optional]` the hostname of the repository                                                                   | `false`  | `github.com`                                                          |
 | is_dry_run                  | `[optional]` set to `true` if you do not want to push the changes and not want to create a PR                 | `false`  |                                                                       |
 | is_allow_hooks              | `[optional]` set to `true` if you want to enable lifecycle hooks. Use this with caution!                      | `false`  | `false`                                                               |
+| hooks | `[optional]` please check the lifecycle hooks section below | `false` | |
 | is_pr_cleanup               | `[optional]` set to `true` if you want to cleanup older PRs targeting the same branch. Use this with caution! | `false`  | `false`                                                               |
 | is_not_source_github        | `[optional]` set to `true` if the source git provider is not GitHub                                           | `false`  | `false`                                                               |
 | is_force_deletion | `[optional]` set to `true` if you want to force delete files which are deleted within the source repository even if they contain changes. You need to also adjust `git_remote_pull_params` (see below for details) | `false` | `false` |
@@ -373,7 +374,8 @@ jobs:
 Different lifecycle hooks are supported. You need to enable the functionality with the option `is_allow_hooks` and set it to `true`
 :warning: use this functionality with caution. You can use one of the available docker images to test it out. **With great power comes great responsibility**.
 
-In addition, you need a configuration file with the name `templatesync.yml` within the root of the target repository.
+In addition, you need either a configuration file with the name `templatesync.yml` within the root of the target repository
+or you set the hooks input parameter within the action definition with a related yaml string
 
 The following hooks are supported (please check [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for a better understanding of the lifecycles).
 
@@ -387,7 +389,26 @@ The following hooks are supported (please check [docs/ARCHITECTURE.md](docs/ARCH
 **Remark** The underlying OS is defined by an Alpine container.
 E.q. for the installation phase you need to use commands like `apk add --update --no-cache python3`
 
-Schema and example for the `templatesync.yml`
+### Example for the hooks input parameter
+
+```yml
+- name: Test action step
+  uses: AndreasAugustin/actions-template-sync@v1
+  env:
+    MY_VAR: "foo"  # possible to define envrionment variables
+  with:
+    source_repo_path: AndreasAugustin/template.git
+    upstream_branch: main
+    is_dry_run: true
+    is_allow_hooks: true
+    hooks: >
+      prepull:
+        commands:
+          - echo 'hi, we are within the prepull phase'
+          - echo 'maybe you want to do adjustments on the local code'
+```
+
+### Schema and example for the `templatesync.yml`
 
 **Remark** It is possible to use environment variables within the github action definition usable within the command configuration, e.g.
 
@@ -397,7 +418,6 @@ Schema and example for the `templatesync.yml`
   env:
     MY_VAR: "foo"  # possible to define envrionment variables
   with:
-    github_token: ${{ secrets.GITHUB_TOKEN }}
     source_repo_path: AndreasAugustin/template.git
     upstream_branch: main
     is_dry_run: true

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,8 @@ inputs:
   is_allow_hooks:
     description: "[optional] set to true if you want to allow hooks. Use this functionality with caution!"
     default: "false"
+  hooks:
+    description: "[optional] define the hooks as yaml string input"
   is_pr_cleanup:
     description: "[optional] set to true if you want to cleanup older PRs targeting the same branch."
     default: "false"
@@ -74,6 +76,7 @@ runs:
     HOSTNAME: ${{ inputs.hostname }}
     IS_DRY_RUN: ${{ inputs.is_dry_run }}
     IS_ALLOW_HOOKS: ${{ inputs.is_allow_hooks }}
+    HOOKS: ${{ inputs.hooks }}
     IS_PR_CLEANUP: ${{ inputs.is_pr_cleanup}}
     IS_NOT_SOURCE_GITHUB: ${{ inputs.is_not_source_github }}
     IS_FORCE_DELETION: ${{ inputs.is_force_deletion }}

--- a/src/sync_common.sh
+++ b/src/sync_common.sh
@@ -49,7 +49,7 @@ function info() {
 function cmd_from_yml_file() {
   local FILE_NAME="templatesync.yml"
   local HOOK=$1
-  local YML_PATH=".hooks.${HOOK}.commands"
+  local YML_PATH_SUFF=".${HOOK}.commands"
 
   if [ "$IS_ALLOW_HOOKS" != "true" ]; then
     debug "execute cmd hooks not enabled"
@@ -64,8 +64,10 @@ function cmd_from_yml_file() {
     if [[ -n "${HOOKS}" ]]; then
       debug "hooks input variable is set. Using the variable"
       echo "${HOOKS}" > "tmp.${FILE_NAME}"
+      YML_PATH="${YML_PATH_SUFF}"
     else
       cp ${FILE_NAME} "tmp.${FILE_NAME}"
+      YML_PATH=".hooks.${YML_PATH_SUFF}"
     fi
 
     readarray cmd_Arr < <(yq "${YML_PATH} | .[]"  "tmp.${FILE_NAME}")

--- a/src/sync_common.sh
+++ b/src/sync_common.sh
@@ -64,7 +64,6 @@ function cmd_from_yml_file() {
     if [[ -n "${HOOKS}" ]]; then
       debug "hooks input variable is set. Using the variable"
       echo "${HOOKS}" > "tmp.${FILE_NAME}"
-      cat "tmp.${FILE_NAME}"
     else
       cp ${FILE_NAME} "tmp.${FILE_NAME}"
     fi

--- a/src/sync_common.sh
+++ b/src/sync_common.sh
@@ -65,12 +65,15 @@ function cmd_from_yml() {
       debug "hooks input variable is set. Using the variable"
       echo "${HOOKS}" > "tmp.${FILE_NAME}"
       YML_PATH="${YML_PATH_SUFF}"
-      info "foo"
     else
       cp ${FILE_NAME} "tmp.${FILE_NAME}"
       YML_PATH=".hooks.${YML_PATH_SUFF}"
-      info "bar"
+      info "${YML_PATH}"
     fi
+
+    info "${YML_PATH}"
+
+    yq "${YML_PATH} | .[]"  "tmp.${FILE_NAME}"
 
     readarray cmd_Arr < <(yq "${YML_PATH} | .[]"  "tmp.${FILE_NAME}")
 

--- a/src/sync_common.sh
+++ b/src/sync_common.sh
@@ -41,12 +41,12 @@ function info() {
 }
 
 #######################################
-# Executes commands defined within yml file
+# Executes commands defined within yml file or env variable
 # Arguments:
 #   hook -> the hook to use
 #
 ####################################3#
-function cmd_from_yml_file() {
+function cmd_from_yml() {
   local FILE_NAME="templatesync.yml"
   local HOOK=$1
   local YML_PATH_SUFF=".${HOOK}.commands"

--- a/src/sync_common.sh
+++ b/src/sync_common.sh
@@ -60,7 +60,8 @@ function cmd_from_yml_file() {
       err "yaml query yq is not installed. 'https://mikefarah.gitbook.io/yq/'";
       exit 1;
     fi
-    readarray cmd_Arr < <(yq "${YML_PATH} | .[]"  "${FILE_NAME}")
+    # readarray cmd_Arr < <(yq "${YML_PATH} | .[]"  "${FILE_NAME}")
+    readarray cmd_Arr < <(yq "${YML_PATH} | .[]" "env(HOOKS)")
 
     for key in "${cmd_Arr[@]}"; do echo "${key}" | bash; done
   fi

--- a/src/sync_common.sh
+++ b/src/sync_common.sh
@@ -67,13 +67,8 @@ function cmd_from_yml() {
       YML_PATH="${YML_PATH_SUFF}"
     else
       cp ${FILE_NAME} "tmp.${FILE_NAME}"
-      YML_PATH=".hooks.${YML_PATH_SUFF}"
-      info "${YML_PATH}"
+      YML_PATH=".hooks${YML_PATH_SUFF}"
     fi
-
-    info "${YML_PATH}"
-
-    yq "${YML_PATH} | .[]"  "tmp.${FILE_NAME}"
 
     readarray cmd_Arr < <(yq "${YML_PATH} | .[]"  "tmp.${FILE_NAME}")
 

--- a/src/sync_common.sh
+++ b/src/sync_common.sh
@@ -65,9 +65,11 @@ function cmd_from_yml() {
       debug "hooks input variable is set. Using the variable"
       echo "${HOOKS}" > "tmp.${FILE_NAME}"
       YML_PATH="${YML_PATH_SUFF}"
+      info "foo"
     else
       cp ${FILE_NAME} "tmp.${FILE_NAME}"
       YML_PATH=".hooks.${YML_PATH_SUFF}"
+      info "bar"
     fi
 
     readarray cmd_Arr < <(yq "${YML_PATH} | .[]"  "tmp.${FILE_NAME}")

--- a/src/sync_common.sh
+++ b/src/sync_common.sh
@@ -60,8 +60,18 @@ function cmd_from_yml_file() {
       err "yaml query yq is not installed. 'https://mikefarah.gitbook.io/yq/'";
       exit 1;
     fi
-    # readarray cmd_Arr < <(yq "${YML_PATH} | .[]"  "${FILE_NAME}")
-    readarray cmd_Arr < <(yq "${YML_PATH} | .[]=env(HOOKS)")
+
+    if [[ -n "${HOOKS}" ]]; then
+      debug "hooks input variable is set. Using the variable"
+      echo "${HOOKS}" > "tmp.${FILE_NAME}"
+      cat "tmp.${FILE_NAME}"
+    else
+      cp ${FILE_NAME} "tmp.${FILE_NAME}"
+    fi
+
+    readarray cmd_Arr < <(yq "${YML_PATH} | .[]"  "tmp.${FILE_NAME}")
+
+    rm "tmp.${FILE_NAME}"
 
     for key in "${cmd_Arr[@]}"; do echo "${key}" | bash; done
   fi

--- a/src/sync_common.sh
+++ b/src/sync_common.sh
@@ -61,7 +61,7 @@ function cmd_from_yml_file() {
       exit 1;
     fi
     # readarray cmd_Arr < <(yq "${YML_PATH} | .[]"  "${FILE_NAME}")
-    readarray cmd_Arr < <(yq "${YML_PATH} | .[]" "env(HOOKS)")
+    readarray cmd_Arr < <(yq "${YML_PATH} | .[]=env(HOOKS)")
 
     for key in "${cmd_Arr[@]}"; do echo "${key}" | bash; done
   fi

--- a/src/sync_template.sh
+++ b/src/sync_template.sh
@@ -34,7 +34,7 @@ fi
 
 GIT_REMOTE_PULL_PARAMS="${GIT_REMOTE_PULL_PARAMS:---allow-unrelated-histories --squash --strategy=recursive -X theirs}"
 
-cmd_from_yml_file "install"
+cmd_from_yml "install"
 
 LOCAL_CURRENT_GIT_HASH=$(git rev-parse HEAD)
 
@@ -81,7 +81,7 @@ fi
 
 echo "::endgroup::"
 
-cmd_from_yml_file "prepull"
+cmd_from_yml "prepull"
 
 echo "::group::Pull template"
 
@@ -129,7 +129,7 @@ if [ "$IS_FORCE_DELETION" == "true" ]; then
   force_delete_files
 fi
 
-cmd_from_yml_file "precommit"
+cmd_from_yml "precommit"
 
 echo "::group::commit changes"
 
@@ -178,7 +178,7 @@ if [ "$IS_DRY_RUN" != "true" ]; then
     if [[ -z "${PR_LABELS}" ]]; then
      warn "env var 'PR_LABELS' is empty. Skipping older prs cleanup"
     else
-      cmd_from_yml_file "precleanup"
+      cmd_from_yml "precleanup"
       cleanup_older_prs
     fi
   else
@@ -244,9 +244,9 @@ function create_pr () {
 echo "::group::push changes and create PR"
 
 if [ "$IS_DRY_RUN" != "true" ]; then
-  cmd_from_yml_file "prepush"
+  cmd_from_yml "prepush"
   push
-  cmd_from_yml_file "prepr"
+  cmd_from_yml "prepr"
   create_pr
 else
     warn "dry_run option is set to off. Skipping push changes and skip create pr"


### PR DESCRIPTION
# Description

Close #467 

now possible to use hooks within action parameters.

e.g.

```yml
- name: Test action step
  uses: AndreasAugustin/actions-template-sync@v1
  with:
    source_repo_path: AndreasAugustin/template.git
    upstream_branch: main
    is_dry_run: true
    is_allow_hooks: true
    hooks: >
      prepull:
        commands:
          - echo 'hi, we are within the prepull phase'
          - echo 'maybe you want to do adjustments on the local code'
```

## Remark

For automation please see [closing-issues-using-keywords](
    https://help.github.com/en/articles/closing-issues-using-keywords)
