### PR TITLE
Fixing passphrase typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,8 +392,8 @@ jobs:
           git_user_name: # add the gpg username
           git_user_email: # add the gpg email
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          # uncomment if your key has a passpharse
-          # gpg_passpharse: ${{ secrets.GPG_PASSPHRASE }}
+          # uncomment if your key has a passphrase
+          # gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
 ```
 


### PR DESCRIPTION
# Description

Hello guys, im configuring this action in my project and i found this typo:

![image](https://github.com/user-attachments/assets/3313fa06-b84e-4f6a-9832-ac232dcac9b8)

So this PR fix the typo in the README:

![image](https://github.com/user-attachments/assets/38036918-f76c-4503-b275-256de50905fe)

Best regards,

Murilo Chianfa