### PR TITLE
fix: incorrect argument passing to git push

### DIFF
--- a/src/sync_template.sh
+++ b/src/sync_template.sh
@@ -293,19 +293,19 @@ function push () {
   local is_force=$2
   local is_with_tags=$3
 
-  local additional_params=" "
+  args=(--set-upstream origin "${branch}")
 
   if [ "$is_force" == true ] ; then
     warn "forcing the push."
-    additional_params="${additional_params}--force "
+    args+=(--force)
   fi
 
   if [ "$is_with_tags" == true ] ; then
     warn "include tags."
-    additional_params="${additional_params}--tags "
+    args+=(--tags)
   fi
 
-  git push "${additional_params}"--set-upstream origin "${branch}"
+  git push "${args[@]}"
 }
 
 ####################################


### PR DESCRIPTION
# Description

Close #573 

Correct way to handle bash arguments is using bash array.

Tested with following script

```
#!/bin/bash
set -ex

function push () {
  local branch=$1
  local is_force=$2
  local is_with_tags=$3

  args=(--set-upstream origin "${branch}")

  if [ "$is_force" == true ] ; then
    args+=(--force)
  fi

  if [ "$is_with_tags" == true ] ; then
    args+=(--tags)
  fi

  git push "${args[@]}"
}

push "main" false false
push "main" true false
push "main" false true
push "main" true true
```

## Remark

For automation please see [closing-issues-using-keywords](
    https://help.github.com/en/articles/closing-issues-using-keywords)
