### PR TITLE
fix(#591): add missing gh cli precheck

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -27,6 +27,11 @@ if [[ -z "${HOME}" ]]; then
   exit 1
 fi
 
+if ! [ -x "$(command -v gh)" ]; then
+  err "github-cli gh is not installed. 'https://github.com/cli/cli'";
+  exit 1;
+fi
+
 ############################################
 # Variables
 ############################################


### PR DESCRIPTION
# Description

Close #591 

add missing precheck for gh cli

## Remark

For automation please see [closing-issues-using-keywords](
    https://help.github.com/en/articles/closing-issues-using-keywords)
