### PR TITLE
fix(#608): workaround

### DIFF
--- a/src/sync_template.sh
+++ b/src/sync_template.sh
@@ -111,7 +111,7 @@ function gh_login_target_github() {
     info "target server url: ${target_repo_hostname}"
     info "logging out of the target if logged in"
     gh auth logout --hostname "${target_repo_hostname}" || debug "not logged in"
-    unset GH_TOKEN
+    unset GITHUB_TOKEN
     info "login to the target git repository"
     gh auth login --git-protocol "https" --hostname "${target_repo_hostname}" --with-token <<< "${TARGET_GH_TOKEN}"
     gh auth setup-git --hostname "${target_repo_hostname}"

--- a/src/sync_template.sh
+++ b/src/sync_template.sh
@@ -111,9 +111,9 @@ function gh_login_target_github() {
     info "target server url: ${target_repo_hostname}"
     info "logging out of the target if logged in"
     gh auth logout --hostname "${target_repo_hostname}" || debug "not logged in"
-    unset GITHUB_TOKEN
+    # unset GITHUB_TOKEN
     info "login to the target git repository"
-    gh auth login --git-protocol "https" --hostname "${target_repo_hostname}" --with-token <<< "${TARGET_GH_TOKEN}"
+    gh auth login --git-protocol "https" --hostname "${target_repo_hostname}" --with-token <<< "${TARGET_GH_TOKEN}" || warn "login with target token somehow did not work. Please consider using the \'target_github_token\` parameter."
     gh auth setup-git --hostname "${target_repo_hostname}"
     gh auth status --hostname "${target_repo_hostname}"
   fi


### PR DESCRIPTION
# Description

Close #608 

A workaround. It is recommended to use `target_github_token` if you need a PAT for the target repository.

## Remark

For automation please see [closing-issues-using-keywords](
    https://help.github.com/en/articles/closing-issues-using-keywords)
