### PR TITLE
feat: add support for `SOURCE_BRANCH`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,9 @@ branding:
   icon: cloud
   color: green
 inputs:
+  source_branch:
+    description: "[optional] the branch to sync from in the source repository. Defaults to the source repo's default branch."
+    required: false
   source_gh_token:
     description: 'GitHub Token for the repo to be synced from. Can be passed in using $\{{ secrets.GITHUB_TOKEN }}'
     required: false
@@ -135,3 +138,4 @@ runs:
         STEPS: ${{ inputs.steps }}
         TEMPLATE_SYNC_IGNORE_FILE_PATH: ${{ inputs.template_sync_ignore_file_path }}
         IS_WITH_TAGS: ${{ inputs.is_with_tags }}
+        SOURCE_BRANCH: ${{ inputs.source_branch }}


### PR DESCRIPTION
# Description

Close #621

See https://github.com/AndreasAugustin/actions-template-sync/issues/621#issuecomment-3142126032

- Adds support for syncing from a non-default SOURCE_BRANCH.
- Skips the commit step if git pull already created a merge commit.
- Keeps the rest of the logic unchanged and close to the original.


## Remark

For automation please see [closing-issues-using-keywords](
    https://help.github.com/en/articles/closing-issues-using-keywords)
