### PR TITLE
GH-673: pr_number output been added

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,15 +321,21 @@ jobs:
 
 > Properties that are available after the action executed.
 
-| output | description |
-| ------ | ----------- |
-| pr_branch | The name of the branch used for the pull request |
-| template_git_hash | The template source repository git hash |
+| output            | description                                       |
+|-------------------|---------------------------------------------------|
+| pr_branch         | The name of the branch used for the pull request  |
+| pr_number         | The number of the pr created for the sync branch  |
+| template_git_hash | The template source repository git hash           |
 
 **Remarks** Please consider following edge cases
 
 * **pr_branch**
   * If PR branch already exists (e.g. after a 2nd run) the action won't update the branch but will still output the branch name
+  * If the remote repository already contains the source repository changes the action will exit and the output variable will be undefined
+  * If there are no changes the action will exit and the output variable will be undefined
+
+* **pr_number**
+  * If PR branch already exists (e.g. after a 2nd run) the action will set pr_number undefined (as there was no created PR's).
   * If the remote repository already contains the source repository changes the action will exit and the output variable will be undefined
   * If there are no changes the action will exit and the output variable will be undefined
 

--- a/action.yml
+++ b/action.yml
@@ -87,6 +87,9 @@ inputs:
     description: "[optional] set to true if tags should be synced"
     default: "false"
 outputs:
+  pr_number:
+    description: "The number of the PR created"
+    value: ${{ steps.sync.outputs.pr_number }}
   pr_branch:
     description: "The name of the PR branch"
     value: ${{ steps.sync.outputs.pr_branch }}

--- a/src/sync_template.sh
+++ b/src/sync_template.sh
@@ -132,6 +132,7 @@ function set_github_action_outputs() {
 
   local pr_branch=$1
   local template_git_hash=$2
+  local pr_number=$3
 
   info "set github action outputs"
 
@@ -141,6 +142,7 @@ function set_github_action_outputs() {
     # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
     echo "pr_branch=${pr_branch}" >> "$GITHUB_OUTPUT"
     echo "template_git_hash=${template_git_hash}" >> "$GITHUB_OUTPUT"
+    echo "pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
   fi
   echo "::endgroup::"
 }
@@ -553,7 +555,7 @@ function arr_prepare_pr_create_pr() {
     create_pr "${PR_TITLE}" "${PR_BODY}" "${UPSTREAM_BRANCH}" "${PR_LABELS}" "${PR_REVIEWERS}"
   fi
 
-
+  export PR_NUMBER="$(gh pr view "${{ steps.sync.outputs.pr_branch }}_123" --json number --jq '.number' 2>/dev/null || true)"
   echo "::endgroup::"
 }
 
@@ -604,4 +606,4 @@ else
   fi
 fi
 
-set_github_action_outputs "${PR_BRANCH}" "${TEMPLATE_GIT_HASH}"
+set_github_action_outputs "${PR_BRANCH}" "${TEMPLATE_GIT_HASH}" "${PR_NUMBER}"

--- a/src/sync_template.sh
+++ b/src/sync_template.sh
@@ -555,7 +555,7 @@ function arr_prepare_pr_create_pr() {
     create_pr "${PR_TITLE}" "${PR_BODY}" "${UPSTREAM_BRANCH}" "${PR_LABELS}" "${PR_REVIEWERS}"
   fi
 
-  export PR_NUMBER="$(gh pr view "${{ steps.sync.outputs.pr_branch }}_123" --json number --jq '.number' 2>/dev/null || true)"
+  export PR_NUMBER="$(gh pr view "$PR_BRANCH" --json number --jq '.number' 2>/dev/null || true)"
   echo "::endgroup::"
 }
 


### PR DESCRIPTION
# Description

Close #673

* Updates of output variables to return `pr_number` created (if it's created)
* readme.md file updated to match the output variables
* gh pr view - is been set not to fail a workflow execution if pr does not exists

## Remark

For automation please see [closing-issues-using-keywords](
    https://help.github.com/en/articles/closing-issues-using-keywords)
