### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,12 @@ on:
 
 jobs:
   call_shellcheck:
+    permissions:
+      contents: read
     uses: ./.github/workflows/shellcheck.yml
   call_lint:
+    permissions:
+      contents: read
     uses: ./.github/workflows/lint.yml
   call_test_all:
     uses: ./.github/workflows/test_all.yml

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -8,6 +8,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     name: Shellcheck


### PR DESCRIPTION
Potential fix for [https://github.com/AndreasAugustin/actions-template-sync/security/code-scanning/3](https://github.com/AndreasAugustin/actions-template-sync/security/code-scanning/3)

Add explicit `permissions` blocks to the reusable-workflow jobs that currently have none.  
For this file, the safest least-privilege change without altering behavior is to set:

- `call_shellcheck`: `permissions: { contents: read }`
- `call_lint`: `permissions: { contents: read }`

This documents intent and prevents broader inherited defaults.  
Edit `.github/workflows/release.yml` in the `jobs` section, directly under each affected job before `uses:`.

No imports, methods, or new definitions are needed (YAML workflow only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
