### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/AndreasAugustin/actions-template-sync/security/code-scanning/7](https://github.com/AndreasAugustin/actions-template-sync/security/code-scanning/7)

Add an explicit `permissions` block to `.github/workflows/lint.yml` at the workflow root (best here since there is only one job and no differing permission needs). Set:
- `contents: read`

This is the minimal least-privilege permission needed for `actions/checkout` and read-only repository access. No imports, methods, or additional definitions are needed (YAML config only).  
Edit region: near the top-level keys, directly after the trigger block (`on:` ...) and before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
