### PR TITLE
chore: configure Copilot cloud agent and dependency automation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,39 @@
+# Copilot instructions
+
+## Repository overview
+
+- This repository contains the `actions-template-sync` GitHub Action.
+- The action implementation is shell-based and lives in `src/`.
+- GitHub Actions workflows are stored in `.github/workflows/`.
+- Docker images and local development services are defined in `Dockerfile` and
+  `docker-compose.yml`.
+
+## Making changes
+
+- Keep changes focused and preserve the existing shell and YAML conventions.
+- Update documentation when changing action inputs, outputs, workflows, or
+  user-facing behavior.
+- Do not expose tokens, private keys, or other credentials in source,
+  workflows, logs, or examples.
+- Pin third-party GitHub Actions to full commit SHAs and include a comment
+  naming the released version.
+- Prefer existing Makefile targets and Docker services over adding new tooling.
+
+## Validation
+
+Run the smallest relevant checks for the files changed:
+
+```bash
+make shellcheck
+make markdownlint
+```
+
+For workflow or action changes, also inspect the YAML and run the applicable
+workflow tests when available.
+
+## Commits and pull requests
+
+- Use Conventional Commits, for example:
+  `fix(sync): handle missing upstream branch`.
+- Follow the repository's pull request template.
+- Summarize behavior changes and validation in the pull request description.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,19 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+  groups:
+    github-actions-minor-and-patch:
+      update-types:
+      - "minor"
+      - "patch"
 - package-ecosystem: docker
   directory: "/"
   schedule:
     interval: weekly
     time: "04:00"
   open-pull-requests-limit: 10
+  groups:
+    docker-minor-and-patch:
+      update-types:
+      - "minor"
+      - "patch"

--- a/.github/workflows/actions_template_sync.yml
+++ b/.github/workflows/actions_template_sync.yml
@@ -21,7 +21,7 @@ jobs:
       - name: actions-template-sync
         uses: AndreasAugustin/actions-template-sync@8a0f668b83c32a0f673353086d74f12b8853d4f5 # v2.5.3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          source_gh_token: ${{ secrets.GITHUB_TOKEN }}
           source_repo_path: AndreasAugustin/template
           upstream_branch: main # defaults to main
           pr_labels: chore,📚 template-sync,example

--- a/.github/workflows/actions_template_sync.yml
+++ b/.github/workflows/actions_template_sync.yml
@@ -17,9 +17,9 @@ jobs:
     steps:
       # To use this repository's private action, you must check out the repository
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: actions-template-sync
-        uses: AndreasAugustin/actions-template-sync@v2
+        uses: AndreasAugustin/actions-template-sync@8a0f668b83c32a0f673353086d74f12b8853d4f5 # v2.5.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           source_repo_path: AndreasAugustin/template

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: ci
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,7 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: markdownlint
         run: make markdownlint
+      - name: shell BDD tests
+        run: make shelltest
       - name: prune
         run: make prune

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,19 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0

--- a/.github/workflows/gh_pages_mk_docs.yml
+++ b/.github/workflows/gh_pages_mk_docs.yml
@@ -11,8 +11,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: 3.x
       - run: pip install mkdocs-material

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: markdownlint
         run: make markdownlint
       - name: prune

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,9 @@ on:
     branches:
       - "!main"
   pull_request:
+
   workflow_call:
+
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/push_docker.yml
+++ b/.github/workflows/push_docker.yml
@@ -35,23 +35,23 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Login to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
             andyaugustin/${{ matrix.variant }}
@@ -59,7 +59,7 @@ jobs:
           tags: |
             type=semver,pattern={{raw}},value=${{ inputs.tag }}${{ matrix.target == 'dev' && '-dev' || '' }}
       - name: Build ${{ matrix.variant }}
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           target: ${{ matrix.target }}
@@ -82,7 +82,7 @@ jobs:
             --image ghcr.io/andreasaugustin/${{ matrix.variant }}:${{ inputs.tag }}${{ matrix.target == 'dev' && '-dev' || '' }}\
             --config docker-test-config.yml
       - name: push ${{ matrix.variant }}
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           target: ${{ matrix.target }}
@@ -90,7 +90,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
       - name: Docker Hub Description
-        uses: peter-evans/dockerhub-description@v5
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release_please.yml
+++ b/.github/workflows/release_please.yml
@@ -23,11 +23,11 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v5
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
           release-type: simple
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: tag major and minor versions
         if: ${{ steps.release.outputs.release_created }}
         run: |

--- a/.github/workflows/release_test_docker_images.yml
+++ b/.github/workflows/release_test_docker_images.yml
@@ -33,17 +33,17 @@ jobs:
           - andyaugustin/actions-template-sync
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           lfs: true
           fetch-depth: 0
       - name: Login to DockerHub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -16,6 +16,6 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Run shellcheck in container
         run: make shellcheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       # To use this repository's private action, you must check out the repository
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Test action step
         id: test
         uses: ./ # Uses an action in the root directory
@@ -38,7 +38,7 @@ jobs:
     steps:
       # To use this repository's private action, you must check out the repository
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Test action step
         id: test
         uses: ./ # Uses an action in the root directory

--- a/.github/workflows/test_github_app.yml
+++ b/.github/workflows/test_github_app.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       # To use this repository's private action, you must check out the repository
       - name: token-generation
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: source-app-token
         with:
           app-id: ${{ secrets.TEST_GITHUB_APP_ID }}
@@ -27,7 +27,7 @@ jobs:
 
       - name: Checkout
         # https://github.com/actions/checkout#usage
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           token: ${{ steps.source-app-token.outputs.token }}
           persist-credentials: false # Don't set this to true as otherwise the token will be stored in the local git config and the run will fail
@@ -43,6 +43,5 @@ jobs:
           upstream_branch: main
           is_dry_run: false
           is_allow_hooks: true
-
 
 

--- a/.github/workflows/test_hooks.yml
+++ b/.github/workflows/test_hooks.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       # To use this repository's private action, you must check out the repository
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Test action step
         uses: ./ # Uses an action in the root directory
         env:

--- a/.github/workflows/test_ssh.yml
+++ b/.github/workflows/test_ssh.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       # To use this repository's private action, you must check out the repository
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Test action step ssh
         if: github.repository_owner == 'AndreasAugustin'
         uses: ./ # Uses an action in the root directory

--- a/.github/workflows/test_ssh_gitlab.yml
+++ b/.github/workflows/test_ssh_gitlab.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       # To use this repository's private action, you must check out the repository
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Test action step ssh
         if: github.repository_owner == 'AndreasAugustin'
         uses: ./ # Uses an action in the root directory

--- a/.github/workflows/test_steps.yml
+++ b/.github/workflows/test_steps.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       # To use this repository's private action, you must check out the repository
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Test action step first steps
         uses: ./ # Uses an action in the root directory

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+default_stages:
+  - pre-commit
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-json
+      - id: check-merge-conflict
+
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.10.0
+    hooks:
+      - id: shellcheck
+
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.45.0
+    hooks:
+      - id: markdownlint

--- a/Makefile
+++ b/Makefile
@@ -35,4 +35,8 @@ prune: ## delete the whole environment
 
 .Phony: shellcheck
 shellcheck:  ## run shellcheck
-	docker compose run shellcheck -x src/*.sh
+	docker compose run shellcheck -x src/*.sh tests/*.sh
+
+.PHONY: shelltest
+shelltest:  ## run shell BDD tests
+	bash tests/sync_common_test.sh

--- a/tests/sync_common_test.sh
+++ b/tests/sync_common_test.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# shellcheck source=src/sync_common.sh
+source "${REPO_ROOT}/src/sync_common.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+describe() {
+  printf '\n%s\n' "$1"
+}
+
+it() {
+  local description=$1
+  shift
+
+  if "$@"; then
+    printf '  \033[32m✓\033[0m %s\n' "${description}"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    printf '  \033[31m✗\033[0m %s\n' "${description}" >&2
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+assert_contains() {
+  local expected=$1
+  local actual=$2
+  [[ "${actual}" == *"${expected}"* ]]
+}
+
+assert_equal() {
+  [[ "$1" == "$2" ]]
+}
+
+test_info_logs_an_info_message() {
+  local output
+  output=$(info "hello")
+  assert_equal "::info::hello" "${output}"
+}
+
+test_warn_logs_a_warning_message() {
+  local output
+  output=$(warn "be careful")
+  assert_equal "::warn::be careful" "${output}"
+}
+
+test_debug_logs_a_debug_message() {
+  local output
+  output=$(debug "details")
+  assert_equal "::debug::details" "${output}"
+}
+
+test_err_logs_an_error_message() {
+  local output
+  output=$(err "failed" 2>&1)
+  assert_contains "::error::" "${output}"
+  assert_contains "failed" "${output}"
+}
+
+test_hooks_are_skipped_when_disabled() {
+  local temp_dir output
+  temp_dir=$(mktemp -d)
+
+  (
+    cd "${temp_dir}"
+    IS_ALLOW_HOOKS=false
+    output=$(cmd_from_yml "precommit")
+    assert_equal "::debug::execute cmd hooks not enabled" "${output}"
+  )
+  rm -rf "${temp_dir}"
+}
+
+test_hooks_execute_commands_from_input() {
+  local temp_dir output
+  temp_dir=$(mktemp -d)
+
+  mkdir -p "${temp_dir}/bin"
+  printf '#!/usr/bin/env bash\nprintf "printf hooked-command\\n"\n' \
+    > "${temp_dir}/bin/yq"
+  chmod +x "${temp_dir}/bin/yq"
+
+  (
+    cd "${temp_dir}"
+    PATH="${temp_dir}/bin:${PATH}"
+    IS_ALLOW_HOOKS=true
+    HOOKS='hooks: []'
+    output=$(cmd_from_yml "precommit")
+    assert_contains "::info::execute cmd hooks enabled" "${output}"
+    assert_contains "hooked-command" "${output}"
+    [[ ! -e tmp.templatesync.yml ]]
+  )
+  rm -rf "${temp_dir}"
+}
+
+describe "sync_common logging"
+it "logs info messages" test_info_logs_an_info_message
+it "logs warning messages" test_warn_logs_a_warning_message
+it "logs debug messages" test_debug_logs_a_debug_message
+it "logs error messages" test_err_logs_an_error_message
+
+describe "sync_common hooks"
+it "skips hooks when disabled" test_hooks_are_skipped_when_disabled
+it "executes commands from hook input" test_hooks_execute_commands_from_input
+
+printf '\n%d passed, %d failed\n' "${PASS_COUNT}" "${FAIL_COUNT}"
+[[ "${FAIL_COUNT}" -eq 0 ]]


### PR DESCRIPTION
## Summary
- group Dependabot minor and patch updates by ecosystem
- add pre-commit checks and immutable GitHub Action pins
- add Copilot instructions and cloud-agent setup steps
- add dependency-free shell BDD unit tests and run them in CI
- rename the lint workflow to CI

## Validation
- YAML configuration validated
- workflow action references pinned to commit SHAs
- 6 shell BDD tests pass
- ShellCheck passes for implementation and tests