### PR TITLE
test(docker): add container structure tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,30 @@ jobs:
         run: make shelltest
       - name: prune
         run: make prune
+
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: build Docker images
+        run: |
+          docker build --target prod --tag actions-template-sync:prod .
+          docker build --target dev --tag actions-template-sync:dev .
+          docker build --target docs --tag actions-template-sync:docs .
+      - name: install container test tools
+        run: |
+          curl -LO https://storage.googleapis.com/container-structure-test/latest/container-structure-test-linux-amd64
+          chmod +x container-structure-test-linux-amd64
+          sudo mv container-structure-test-linux-amd64 /usr/local/bin/container-structure-test
+      - name: test Docker images
+        run: |
+          container-structure-test test \
+            --image actions-template-sync:prod \
+            --config docker-test-config.yml
+          container-structure-test test \
+            --image actions-template-sync:dev \
+            --config docker-test-config.yml
+          container-structure-test test \
+            --image actions-template-sync:docs \
+            --config docker-docs-test-config.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,10 @@ RUN tar --strip-components=1 -xf ghcli.tar.gz \
     && rm ghcli.tar.gz
 
 ADD src/*.sh /bin/
-RUN chmod +x /bin/entrypoint.sh \
-  && chmod +x /bin/sync_template.sh \
-  && chmod +x /bin/sync_common.sh \
-  && chmod +x /bin/gpg_no_tty.sh
+RUN chmod 755 /bin/entrypoint.sh \
+  && chmod 755 /bin/sync_template.sh \
+  && chmod 755 /bin/sync_common.sh \
+  && chmod 755 /bin/gpg_no_tty.sh
 
 RUN mkdir -p /root/.ssh \
   && ssh-keyscan -t rsa github.com >> /root/.ssh/known_hosts

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,10 @@ RUN chmod +x /bin/entrypoint.sh \
 RUN mkdir -p /root/.ssh \
   && ssh-keyscan -t rsa github.com >> /root/.ssh/known_hosts
 
+WORKDIR /app
+
+RUN git config --global --add safe.directory /app/
+
 ENTRYPOINT ["/bin/bash", "/bin/entrypoint.sh"]
 #######################################
 # image for dev build environment

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,10 @@ RUN mkdir -p /root/.ssh \
 
 WORKDIR /app
 
+ADD src/*.sh /app/src/
+ADD tests/*.sh /app/tests/
+ADD action.yml /app/action.yml
+
 RUN git config --global --add safe.directory /app/
 
 ENTRYPOINT ["/bin/bash", "/bin/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,21 @@ shellcheck:  ## run shellcheck
 shelltest:  ## run shell BDD tests
 	bash tests/sync_common_test.sh
 	bash tests/sync_template_test.sh
+
+.PHONY: docker-test
+docker-test: ## build and test all Docker image targets
+	docker build --target prod --tag actions-template-sync:prod .
+	docker build --target dev --tag actions-template-sync:dev .
+	docker build --target docs --tag actions-template-sync:docs .
+	@container_structure_test="$$(mktemp)"; \
+	trap 'rm -f "$$container_structure_test"' EXIT; \
+	curl --fail --silent --show-error \
+		https://storage.googleapis.com/container-structure-test/latest/container-structure-test-linux-amd64 \
+		-o "$$container_structure_test"; \
+	chmod +x "$$container_structure_test"; \
+	"$$container_structure_test" test \
+		--image actions-template-sync:prod --config docker-test-config.yml; \
+	"$$container_structure_test" test \
+		--image actions-template-sync:dev --config docker-test-config.yml; \
+	"$$container_structure_test" test \
+		--image actions-template-sync:docs --config docker-docs-test-config.yml

--- a/docker-docs-test-config.yml
+++ b/docker-docs-test-config.yml
@@ -1,0 +1,23 @@
+schemaVersion: '2.0.0'
+metadataTest:
+  entrypoint: ["docker-entrypoint.sh"]
+  workdir: "/app"
+fileExistenceTests:
+  - name: "markdownlint is installed"
+    path: "/usr/local/bin/markdownlint"
+    shouldExist: true
+  - name: "zsh is installed"
+    path: "/bin/zsh"
+    shouldExist: true
+  - name: "tmux is installed"
+    path: "/usr/bin/tmux"
+    shouldExist: true
+commandTests:
+  - name: "node is installed"
+    command: "which"
+    args: ["node"]
+    expectedOutput: ["/usr/local/bin/node"]
+  - name: "npm is installed"
+    command: "which"
+    args: ["npm"]
+    expectedOutput: ["/usr/local/bin/npm"]

--- a/docker-test-config.yml
+++ b/docker-test-config.yml
@@ -12,6 +12,15 @@ fileExistenceTests:
   - name: "SSH known hosts are configured"
     path: "/root/.ssh/known_hosts"
     shouldExist: true
+  - name: "shell tests are present"
+    path: "/app/tests/sync_common_test.sh"
+    shouldExist: true
+  - name: "shell test helpers are present"
+    path: "/app/tests/test_common.sh"
+    shouldExist: true
+  - name: "action metadata is present"
+    path: "/app/action.yml"
+    shouldExist: true
 commandTests:
   - name: "gh is installed"
     command: "which"
@@ -25,3 +34,11 @@ commandTests:
     command: "which"
     args: ["git"]
     expectedOutput: ["/usr/bin/git"]
+  - name: "sync common shell tests pass"
+    command: "bash"
+    args: ["/app/tests/sync_common_test.sh"]
+    expectedOutput: ["TEST RESULTS: 18 passed, 0 failed"]
+  - name: "sync template shell tests pass"
+    command: "bash"
+    args: ["/app/tests/sync_template_test.sh"]
+    expectedOutput: ["TEST RESULTS: 3 passed, 0 failed"]

--- a/docker-test-config.yml
+++ b/docker-test-config.yml
@@ -1,6 +1,27 @@
 schemaVersion: '2.0.0'
+metadataTest:
+  workdir: "/app"
+fileExistenceTests:
+  - name: "entrypoint is present"
+    path: "/bin/entrypoint.sh"
+    shouldExist: true
+    permissions: "-rwxrwxr-x"
+  - name: "sync scripts are present"
+    path: "/bin/sync_common.sh"
+    shouldExist: true
+  - name: "SSH known hosts are configured"
+    path: "/root/.ssh/known_hosts"
+    shouldExist: true
 commandTests:
   - name: "gh is installed"
     command: "which"
     args: ["gh"]
     expectedOutput: ["/bin/gh"]
+  - name: "bash is installed"
+    command: "which"
+    args: ["bash"]
+    expectedOutput: ["/bin/bash"]
+  - name: "git is installed"
+    command: "which"
+    args: ["git"]
+    expectedOutput: ["/usr/bin/git"]

--- a/docker-test-config.yml
+++ b/docker-test-config.yml
@@ -5,7 +5,7 @@ fileExistenceTests:
   - name: "entrypoint is present"
     path: "/bin/entrypoint.sh"
     shouldExist: true
-    permissions: "-rwxrwxr-x"
+    permissions: "-rwxr-xr-x"
   - name: "sync scripts are present"
     path: "/bin/sync_common.sh"
     shouldExist: true

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -7,9 +7,113 @@ If you want to test things out or if you want to build your own action (e.g. in 
 - [github registry][github-repo]
 - [dockerhub registry][dockerhub-repo]
 
-## Use the image
+## Use the production image
 
-TODO
+The production image runs the same synchronization script used by the GitHub
+Action. It expects the target repository to be mounted into the container and
+requires tokens for both the source and target repositories.
+
+The image entrypoint requires these environment variables:
+
+| Variable | Description |
+| --- | --- |
+| `SOURCE_GH_TOKEN` | Token with read access to the source repository |
+| `TARGET_GH_TOKEN` | Token with permission to create branches and pull requests in the target repository |
+| `SOURCE_REPO_PATH` | Source repository path, for example `owner/template-repository` |
+| `GITHUB_SERVER_URL` | GitHub server URL, for example `https://github.com` |
+
+The container should run from the mounted target repository. Git, GitHub CLI,
+SSH, Git LFS, and the synchronization scripts are included in the image.
+
+### Pull and run
+
+Use either registry image. Replace `v2` with the desired release tag:
+
+```bash
+docker run --rm \
+  --workdir /github/workspace \
+  --volume "$PWD:/github/workspace" \
+  --env SOURCE_GH_TOKEN \
+  --env TARGET_GH_TOKEN \
+  --env SOURCE_REPO_PATH=owner/template-repository \
+  --env UPSTREAM_BRANCH=main \
+  --env GITHUB_SERVER_URL=https://github.com \
+  --env GITHUB_ACTOR=automation \
+  ghcr.io/andreasaugustin/actions-template-sync:v2
+```
+
+The same command using Docker Hub is:
+
+```bash
+docker run --rm \
+  --workdir /github/workspace \
+  --volume "$PWD:/github/workspace" \
+  --env SOURCE_GH_TOKEN \
+  --env TARGET_GH_TOKEN \
+  --env SOURCE_REPO_PATH=owner/template-repository \
+  --env GITHUB_SERVER_URL=https://github.com \
+  andyaugustin/actions-template-sync:v2
+```
+
+The `--env NAME` form reads the value from the host environment. Set the token
+variables without putting their values in shell history:
+
+```bash
+export SOURCE_GH_TOKEN='source-token'
+export TARGET_GH_TOKEN='target-token'
+export SOURCE_REPO_PATH='owner/template-repository'
+```
+
+For repeatable runs, put non-secret configuration in an environment file and
+provide secrets through the environment or a secret manager:
+
+```dotenv
+SOURCE_REPO_PATH=owner/template-repository
+UPSTREAM_BRANCH=main
+GITHUB_SERVER_URL=https://github.com
+GITHUB_ACTOR=automation
+```
+
+```bash
+docker run --rm \
+  --env-file ./templatesync.env \
+  --env SOURCE_GH_TOKEN \
+  --env TARGET_GH_TOKEN \
+  --workdir /github/workspace \
+  --volume "$PWD:/github/workspace" \
+  ghcr.io/andreasaugustin/actions-template-sync:v2
+```
+
+### Private source repositories over SSH
+
+Set `SSH_PRIVATE_KEY_SRC` to use SSH instead of the GitHub CLI token for the
+source repository. The image already contains GitHub's SSH host key.
+
+```bash
+docker run --rm \
+  --workdir /github/workspace \
+  --volume "$PWD:/github/workspace" \
+  --env SSH_PRIVATE_KEY_SRC \
+  --env TARGET_GH_TOKEN \
+  --env SOURCE_REPO_PATH=owner/private-template \
+  --env GITHUB_SERVER_URL=https://github.com \
+  ghcr.io/andreasaugustin/actions-template-sync:v2
+```
+
+For GitHub Enterprise or another Git provider, set `HOSTNAME` to the source
+host and use the matching `GITHUB_SERVER_URL`.
+
+### Build the image locally
+
+Build the production target from a checkout of this repository:
+
+```bash
+docker build --target prod \
+  --tag actions-template-sync:prod .
+```
+
+Then replace the registry image name in the examples with
+`actions-template-sync:prod`.
 
 [dockerhub-repo]: https://hub.docker.com/r/andyaugustin/actions-template-sync
 [github-repo]: https://github.com/AndreasAugustin/actions-template-sync/pkgs/container/actions-template-sync


### PR DESCRIPTION
Close #651 

## Summary
- add container structure tests for prod and dev images
- execute the shell test suites inside the production image
- add structure tests for the docs image
- add CI and Makefile coverage for building and testing all Docker targets
- normalize production script permissions to `755` for reproducible remote tests

## Validation
- `make docker-test`