### PR TITLE
feat(sync): support selecting source branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ jobs:
 | source_gh_token | `[optional]` used for the source github repo token. Can be passed in using `${{ secrets.GITHUB_TOKEN }}` | `false` | `${{ github.token }}` |
 | target_gh_token | `[optional]` used for the source github repo token. Can be passed in using `${{ secrets.GITHUB_TOKEN }}` | `false` | `${{ github.token }}` |
 | source_repo_path | Repository path of the template | `true` | |
+| source_branch | Branch of the source repository to synchronize | `false` | The source repository's default branch |
 | upstream_branch | The target branch | `false` | The remote's default (usually `main`) |
 | source_repo_ssh_private_key | `[optional]` private ssh key for the source repository. [see](#private-template-repository) | `false` | |
 | pr_branch_name_prefix | `[optional]` the prefix of branches created by this action | `false` | `chore/template_sync` |

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,8 @@ inputs:
   source_repo_path:
     description: "Repository path of the template"
     required: true
+  source_branch:
+    description: "[optional] branch of the source repository to synchronize"
   upstream_branch:
     description: "The target branch"
   source_repo_ssh_private_key:
@@ -120,6 +122,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github_token }}
         #
         SOURCE_REPO_PATH: ${{ inputs.source_repo_path }}
+        SOURCE_BRANCH: ${{ inputs.source_branch }}
         UPSTREAM_BRANCH: ${{ inputs.upstream_branch }}
         SSH_PRIVATE_KEY_SRC: ${{ inputs.source_repo_ssh_private_key }}
         PR_BRANCH_NAME_PREFIX: ${{ inputs.pr_branch_name_prefix }}

--- a/docker-test-config.yml
+++ b/docker-test-config.yml
@@ -41,4 +41,4 @@ commandTests:
   - name: "sync template shell tests pass"
     command: "bash"
     args: ["/app/tests/sync_template_test.sh"]
-    expectedOutput: ["TEST RESULTS: 3 passed, 0 failed"]
+    expectedOutput: ["TEST RESULTS: 5 passed, 0 failed"]

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -20,6 +20,7 @@ The image entrypoint requires these environment variables:
 | `SOURCE_GH_TOKEN` | Token with read access to the source repository |
 | `TARGET_GH_TOKEN` | Token with permission to create branches and pull requests in the target repository |
 | `SOURCE_REPO_PATH` | Source repository path, for example `owner/template-repository` |
+| `SOURCE_BRANCH` | Optional source branch to synchronize; defaults to the source repository's default branch |
 | `GITHUB_SERVER_URL` | GitHub server URL, for example `https://github.com` |
 
 The container should run from the mounted target repository. Git, GitHub CLI,
@@ -36,6 +37,7 @@ docker run --rm \
   --env SOURCE_GH_TOKEN \
   --env TARGET_GH_TOKEN \
   --env SOURCE_REPO_PATH=owner/template-repository \
+  --env SOURCE_BRANCH=develop \
   --env UPSTREAM_BRANCH=main \
   --env GITHUB_SERVER_URL=https://github.com \
   --env GITHUB_ACTOR=automation \

--- a/src/sync_template.sh
+++ b/src/sync_template.sh
@@ -70,6 +70,14 @@ if [[ "${IS_SYNC_TO_LATEST_SEMVER}" == "true" ]]; then
   SOURCE_PULL_REF="refs/tags/${LATEST_SEMVER_TAG}"
   TEMPLATE_REMOTE_GIT_HASH="$(get_remote_tag_commit "${SOURCE_REPO}" "${SOURCE_PULL_REF}")"
   info "syncing to latest semantic version tag: ${LATEST_SEMVER_TAG}"
+elif [[ -n "${SOURCE_BRANCH}" ]]; then
+  SOURCE_PULL_REF="refs/heads/${SOURCE_BRANCH}"
+  TEMPLATE_REMOTE_GIT_HASH=$(git ls-remote "${SOURCE_REPO}" "${SOURCE_PULL_REF}" | awk '{print $1}')
+  if [[ -z "${TEMPLATE_REMOTE_GIT_HASH}" ]]; then
+    err "Source branch '${SOURCE_BRANCH}' was not found in '${SOURCE_REPO}'."
+    exit 1
+  fi
+  info "syncing source branch: ${SOURCE_BRANCH}"
 else
   TEMPLATE_REMOTE_GIT_HASH=$(git ls-remote "${SOURCE_REPO}" HEAD | awk '{print $1}')
 fi

--- a/tests/sync_template_test.sh
+++ b/tests/sync_template_test.sh
@@ -22,6 +22,7 @@ create_source_repository() {
   git -C "${work_dir}" add file
   git -C "${work_dir}" commit --quiet -m initial
   git -C "${work_dir}" tag v1.0.0
+  git -C "${work_dir}" branch source-branch
 
   printf 'release\n' >> "${work_dir}/file"
   git -C "${work_dir}" add file
@@ -116,8 +117,16 @@ test_action_wires_semver_inputs() {
   assert_contains "IS_INCLUDE_PRERELEASE: \${{ inputs.is_include_prerelease }}" "${action}"
 }
 
+test_action_wires_source_branch_input() {
+  local action
+  action=$(<"${REPO_ROOT}/action.yml")
+  assert_contains "source_branch:" "${action}"
+  assert_contains "SOURCE_BRANCH: \${{ inputs.source_branch }}" "${action}"
+}
+
 it "syncs to the latest stable semantic version" test_sync_uses_latest_stable_semver
 it "syncs to the latest prerelease when enabled" test_sync_uses_latest_prerelease_when_enabled
 it "wires semantic-version inputs in action.yml" test_action_wires_semver_inputs
+it "wires the source branch input in action.yml" test_action_wires_source_branch_input
 
 finish_tests

--- a/tests/sync_template_test.sh
+++ b/tests/sync_template_test.sh
@@ -35,6 +35,7 @@ create_source_repository() {
   git -C "${work_dir}" tag v9.0.0-rc1
 
   git -C "${work_dir}" push --quiet "${remote_dir}" HEAD --tags
+  git -C "${work_dir}" push --quiet "${remote_dir}" source-branch
   printf '%s\n' "${remote_dir}"
 }
 
@@ -78,6 +79,44 @@ run_sync_to_latest_semver() {
   printf '%s\n' "${output_file}"
 }
 
+run_sync_to_source_branch() {
+  local temp_dir=$1
+  local source_repository=$2
+  local target_dir="${temp_dir}/target-source-branch"
+  local output_file="${temp_dir}/output-source-branch"
+  local github_output="${temp_dir}/github-output-source-branch"
+  local fake_bin="${temp_dir}/bin"
+
+  mkdir -p "${fake_bin}" "${target_dir}"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "${fake_bin}/gh"
+  chmod +x "${fake_bin}/gh"
+
+  git -C "${target_dir}" init --quiet
+  git -C "${target_dir}" config user.email test@example.com
+  git -C "${target_dir}" config user.name test
+  git -C "${target_dir}" config pull.rebase false
+  git -C "${target_dir}" commit --quiet --allow-empty -m target
+
+  (
+    cd "${target_dir}"
+    PATH="${fake_bin}:${PATH}" \
+      SOURCE_REPO="${source_repository}" \
+      SOURCE_BRANCH="source-branch" \
+      PR_COMMIT_MSG="sync" \
+      GITHUB_SERVER_URL="https://github.com" \
+      UPSTREAM_BRANCH="main" \
+      TEMPLATE_SYNC_IGNORE_FILE_PATH=".templatesyncignore" \
+      PR_BRANCH_NAME_PREFIX="chore/template_sync" \
+      IS_FORCE_PUSH_PR=true \
+      IS_DRY_RUN=true \
+      STEPS="pull" \
+      GITHUB_OUTPUT="${github_output}" \
+      bash "${REPO_ROOT}/src/sync_template.sh"
+  ) > "${output_file}"
+
+  printf '%s\n' "${output_file}"
+}
+
 test_sync_uses_latest_stable_semver() {
   local temp_dir source_repository output_file output
   temp_dir=$(mktemp -d)
@@ -108,6 +147,21 @@ test_sync_uses_latest_prerelease_when_enabled() {
   rm -rf "${temp_dir}"
 }
 
+test_sync_uses_configured_source_branch() {
+  local temp_dir source_repository output_file output
+  temp_dir=$(mktemp -d)
+  source_repository=$(create_source_repository "${temp_dir}")
+  output_file=$(run_sync_to_source_branch "${temp_dir}" "${source_repository}")
+  output=$(<"${output_file}")
+
+  assert_contains "::info::syncing source branch: source-branch" "${output}"
+  grep -q '^stable$' "${temp_dir}/target-source-branch/file"
+  if grep -q '^release$' "${temp_dir}/target-source-branch/file"; then
+    return 1
+  fi
+  rm -rf "${temp_dir}"
+}
+
 test_action_wires_semver_inputs() {
   local action
   action=$(<"${REPO_ROOT}/action.yml")
@@ -126,6 +180,7 @@ test_action_wires_source_branch_input() {
 
 it "syncs to the latest stable semantic version" test_sync_uses_latest_stable_semver
 it "syncs to the latest prerelease when enabled" test_sync_uses_latest_prerelease_when_enabled
+it "syncs from the configured source branch" test_sync_uses_configured_source_branch
 it "wires semantic-version inputs in action.yml" test_action_wires_semver_inputs
 it "wires the source branch input in action.yml" test_action_wires_source_branch_input
 


### PR DESCRIPTION
## Summary
- add an optional `source_branch` action input
- synchronize a selected source branch while preserving target branch behavior
- document the option for Action and Docker users

## Validation
- `bash tests/sync_template_test.sh`
- `make shellcheck`
- markdown lint